### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -12,7 +12,7 @@ jobs:
      steps:
        - uses: actions/checkout@v2
        - name: Publish Docker to Docker Hub
-         uses: elgohr/Publish-Docker-Github-Action@master
+         uses: elgohr/Publish-Docker-Github-Action@v5
          with:
            name: restbase/base_image
            username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore